### PR TITLE
ci(interpreter): configura fluxos de integração contínua

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,145 @@
+name: Pre-release
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build-binaries:
+    name: Build Binary - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact-name: linux-x86_64
+            binary-extension: ''
+            ghc: "9.6.7"
+            cabal: "3.12"
+          - os: macos-latest
+            artifact-name: macos-x86_64
+            binary-extension: ''
+            ghc: "9.6.7"
+            cabal: "3.12"
+          - os: windows-latest
+            artifact-name: windows-x86_64
+            binary-extension: '.exe'
+            ghc: "9.6.7"
+            cabal: "3.12"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Haskell
+      uses: haskell-actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+
+    - name: Cache cabal store
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cabal/store
+          ~/.cabal/packages
+          dist-newstyle
+        key: ${{ runner.os }}-cabal-release-${{ hashFiles('**/*.cabal', '**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-cabal-release-
+
+    - name: Update cabal
+      run: cabal update
+
+    - name: Build project
+      run: cabal build exe:brainfuchs
+
+    - name: Run tests
+      run: cabal test --test-show-details=direct
+
+    - name: Get binary name
+      id: get-binary
+      shell: bash
+      run: |
+        BINARY_PATH=$(cabal list-bin exe:brainfuchs)
+        echo "binary-path=$BINARY_PATH" >> $GITHUB_OUTPUT
+        BINARY_NAME=$(basename "$BINARY_PATH")
+        echo "binary-name=$BINARY_NAME" >> $GITHUB_OUTPUT
+
+    - name: Strip binary (Unix)
+      if: matrix.os != 'windows-latest'
+      run: strip ${{ steps.get-binary.outputs.binary-path }}
+
+    - name: Create release directory
+      run: mkdir -p release
+
+    - name: Copy binary to release directory
+      shell: bash
+      run: |
+        BIN_PATH="${{ steps.get-binary.outputs.binary-path }}"
+        # Substitui '\' por '/' para normalização de caminhos no Windows usando bash shell.
+        BIN_PATH=$(echo "$BIN_PATH" | sed 's#\\#/#g')
+
+        cp "$BIN_PATH" "release/brainfuchs-${{ matrix.artifact-name }}${{ matrix.binary-extension }}"
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: binary-${{ matrix.artifact-name }}
+        path: release/*
+
+  create-pre-release:
+    name: Create Pre-release
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Get version from cabal file
+      id: get-version
+      run: |
+        VERSION=$(grep -E "^version:" *.cabal | head -1 | awk '{print $2}')
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Current version: $VERSION"
+
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: binaries
+
+    - name: Display structure of downloaded files
+      run: ls -R binaries
+
+    - name: Generate pre-release tag
+      id: tag
+      run: |
+        SHORT_SHA=$(git rev-parse --short HEAD)
+        TAG="v${{ steps.get-version.outputs.version }}-beta-${SHORT_SHA}"
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
+        echo "short-sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+
+    - name: Create Pre-release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.tag.outputs.tag }}
+        name: Pre-release ${{ steps.tag.outputs.tag }}
+        body: |
+          Pré-lançamento
+
+          **Versão:** ${{ steps.get-version.outputs.version }}
+          **Commit:** ${{ github.sha }}
+          **Branch:** develop
+
+          ⚠️ Versão beta para testes.
+        draft: false
+        prerelease: true
+        files: |
+          binaries/binary-linux-x86_64/*
+          binaries/binary-macos-x86_64/*
+          binaries/binary-windows-x86_64/*
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,254 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  validate-tag:
+    name: Validate Tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.validate.outputs.version }}
+      tag-version: ${{ steps.validate.outputs.tag-version }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Get version from cabal file
+      id: get-version
+      run: |
+        VERSION=$(grep -E "^version:" *.cabal | head -1 | awk '{print $2}')
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Cabal version: $VERSION"
+
+    - name: Validate tag matches cabal version
+      id: validate
+      run: |
+        TAG_VERSION=${GITHUB_REF#refs/tags/v}
+        CABAL_VERSION="${{ steps.get-version.outputs.version }}"
+
+        echo "tag-version=$TAG_VERSION" >> $GITHUB_OUTPUT
+        echo "version=$CABAL_VERSION" >> $GITHUB_OUTPUT
+
+        if [ "$TAG_VERSION" != "$CABAL_VERSION" ]; then
+          echo "❌ Error: Tag version ($TAG_VERSION) does not match cabal version ($CABAL_VERSION)"
+          exit 1
+        fi
+
+        echo "✅ Tag version matches cabal version: $TAG_VERSION"
+
+  build-binaries:
+    name: Build Binary - ${{ matrix.os }}
+    needs: validate-tag
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact-name: linux-x86_64
+            binary-extension: ''
+            ghc: "9.6.7"
+            cabal: "3.12"
+          - os: macos-latest
+            artifact-name: macos-x86_64
+            binary-extension: ''
+            ghc: "9.6.7"
+            cabal: "3.12"
+          - os: windows-latest
+            artifact-name: windows-x86_64
+            binary-extension: '.exe'
+            ghc: "9.6.7"
+            cabal: "3.12"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Haskell
+      uses: haskell-actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+
+    - name: Cache cabal store
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cabal/store
+          ~/.cabal/packages
+          dist-newstyle
+        key: ${{ runner.os }}-cabal-release-${{ hashFiles('**/*.cabal', '**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-cabal-release-
+
+    - name: Update cabal
+      run: cabal update
+
+    - name: Build project
+      run: cabal build exe:brainfuchs
+
+    - name: Run tests
+      run: cabal test --test-show-details=direct
+
+    - name: Get binary name
+      id: get-binary
+      shell: bash
+      run: |
+        BINARY_PATH=$(cabal list-bin exe:brainfuchs)
+        echo "binary-path=$BINARY_PATH" >> $GITHUB_OUTPUT
+        BINARY_NAME=$(basename "$BINARY_PATH")
+        echo "binary-name=$BINARY_NAME" >> $GITHUB_OUTPUT
+
+    - name: Strip binary (Unix)
+      if: matrix.os != 'windows-latest'
+      run: strip ${{ steps.get-binary.outputs.binary-path }}
+
+    - name: Create release directory
+      run: mkdir -p release
+
+    - name: Copy binary to release directory
+      shell: bash
+      run: |
+        BIN_PATH="${{ steps.get-binary.outputs.binary-path }}"
+        # Substitui '\' por '/' para normalização de caminhos no Windows usando bash shell.
+        BIN_PATH=$(echo "$BIN_PATH" | sed 's#\\#/#g')
+
+        cp "$BIN_PATH" "release/brainfuchs-${{ matrix.artifact-name }}${{ matrix.binary-extension }}"
+
+    - name: Create archive (Unix)
+      if: matrix.os != 'windows-latest'
+      run: |
+        cd release
+        tar -czf brainfuchs-v${{ needs.validate-tag.outputs.version }}-${{ matrix.artifact-name }}.tar.gz *
+
+    - name: Create archive (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        cd release
+        7z a brainfuchs-v${{ needs.validate-tag.outputs.version }}-${{ matrix.artifact-name }}.zip *
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.artifact-name }}
+        path: release/*
+        if-no-files-found: ignore
+
+    - name: Generate documentation
+      if: matrix.os == 'ubuntu-latest'
+      run: cabal haddock --haddock-hyperlink-source --haddock-quickjump
+
+    - name: Prepare documentation for GitHub Pages
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        # Busca diretório da documentação gerada
+        DOC_DIR=$(find dist-newstyle -type d -path "*/doc/html/*" -name "brainfuchs" | head -1)
+
+        if [ -z "$DOC_DIR" ]; then
+          echo "Documentation directory not found"
+          exit 1
+        fi
+
+        mkdir -p gh-pages
+        cp -r "$DOC_DIR"/* gh-pages/
+
+        echo "Documentation prepared in gh-pages/"
+        ls -la gh-pages/
+
+    - name: Upload documentation artifact
+      if: matrix.os == 'ubuntu-latest'
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: gh-pages/
+
+  deploy-documentation:
+    name: Deploy Documentation to GitHub Pages
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+    - name: Deploy to GitHub Pages
+      uses: actions/deploy-pages@v4
+
+  create-release:
+    name: Create Stable Release
+    needs: [validate-tag, build-binaries]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: binaries
+
+    - name: Display structure of downloaded files
+      run: ls -R binaries
+
+    - name: Extract changelog for version
+      id: changelog
+      run: |
+        VERSION="${{ needs.validate-tag.outputs.version }}"
+
+        # Verifica se existe um CHANGELOG.md
+        if [ ! -f CHANGELOG.md ]; then
+          # Fallback
+          echo "⚠️ CHANGELOG.md not found, creating generic release notes"
+          echo "## Release v${VERSION}" > RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+
+          echo "Release notes:"
+          cat RELEASE_NOTES.md
+          exit 0
+        fi
+
+        # Extrai a seção da versão atual
+        # Busca primeira ocorrência do padrão "## [1.2.3.0] - YYYY-MM-DD" ou "## 1.2.3.0 -- YYYY-MM-DD"
+        awk -v version="$VERSION" '
+          BEGIN { print_section=0 }
+          /^## / {
+            if (print_section) exit
+            if ($0 ~ version) {
+              print_section=1
+              print $0
+              next
+            }
+          }
+          print_section { print }
+        ' CHANGELOG.md > RELEASE_NOTES.md
+
+        # Verifica se encontrou alguma seção para a versão atual
+        if [ ! -s RELEASE_NOTES.md ]; then
+          # Fallback
+          echo "⚠️ No changelog entry found for version ${VERSION}"
+          echo "## Release v${VERSION}" > RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+          echo "Veja [CHANGELOG.md](CHANGELOG.md) para mais detalhes" >> RELEASE_NOTES.md
+        fi
+
+        echo "Release notes:"
+        cat RELEASE_NOTES.md
+
+    - name: Create Stable Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: v${{ needs.validate-tag.outputs.version }}
+        name: Release v${{ needs.validate-tag.outputs.version }}
+        body_path: RELEASE_NOTES.md
+        draft: false
+        prerelease: false
+        files: |
+          binaries/linux-x86_64/*
+          binaries/macos-x86_64/*
+          binaries/windows-x86_64/*
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [ develop, main ]
+
+jobs:
+  build-and-test:
+    name: Build and Test - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        ghc: ['9.6.7']
+        cabal: ['3.12']
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Haskell
+      uses: haskell-actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+
+    - name: Cache cabal store
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cabal/store
+          ~/.cabal/packages
+          dist-newstyle
+        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-${{ hashFiles('**/*.cabal', '**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.ghc }}-cabal-
+
+    - name: Update cabal package list
+      run: cabal update
+
+    - name: Build project
+      run: cabal build exe:brainfuchs
+
+    - name: Run tests
+      run: cabal test --test-show-details=direct
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
-# Revision history for brainfuchs
+# Changelog
 
-## 0.1.0.0 -- YYYY-mm-dd
+All notable changes to this project will be documented in this file.
 
-* First version. Released on an unsuspecting world.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to the [Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## [Unreleased]
+
+### Added
+- Initial implementation of the brainfuck interpreter.
+- Library modules:
+  - `Brainfuck.Parser` – parse Brainfuck code into commands.
+  - `Brainfuck.Evaluator` – run Brainfuck programs.
+  - `Brainfuck.Types` – core types (e.g. Tape, Instructions).
+- Executable `brainfuchs` with CLI entry point in `app/Main.hs`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,21 @@
-Copyright (c) 2025 ADS 6 ciclo
+MIT License
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+Copyright (c) 2025 BrainfucHS project authors
 
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/brainfuchs.cabal
+++ b/brainfuchs.cabal
@@ -1,11 +1,12 @@
 cabal-version:      3.0
 name:               brainfuchs
-version:            0.1.0.0
-synopsis:           Um interpretador para a linguagem Brainfuck em Haskell
+version:            0.1.0
+synopsis:           Minimal Brainfuck interpreter in Haskell
+description:        Um interpretador minimalista para a linguagem Brainfuck, escrito em Haskell.
 license:            MIT
 license-file:       LICENSE
-author:             ADS 6 ciclo
-maintainer:         nathan.holtz0805@gmail.com
+author:             BrainfucHS project authors
+maintainer:         BrainfucHS project maintainers <https://github.com/igorMSoares/brainfuchs>
 build-type:         Simple
 extra-doc-files:    CHANGELOG.md
 
@@ -21,12 +22,12 @@ library
         Brainfuck.Parser,
         Brainfuck.Types
     build-depends:
-        mtl 
+        mtl
     hs-source-dirs:   interpreter/src
 
 executable brainfuchs
     import:           common-settings
     main-is:          Main.hs
     build-depends:
-        brainfuchs 
+        brainfuchs
     hs-source-dirs:   app

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -18,43 +18,52 @@ Para uma compreensão completa do design e filosofia por trás deste interpretad
 O projeto segue a estrutura padrão de projetos Haskell para garantir uma separação limpa entre o código de biblioteca reutilizável e o código executável. Isso é crítico para permitir que outras equipes (ex., a equipe do compilador) dependam da lógica central Brainfuck sem depender da implementação do REPL.
 
 ```
-interpreter/
-├── ARCHITECTURE.md
-├── MODULE_SPECIFICATIONS.md
-├── README.md
-│
-└───src
-    ├── Brainfuck
-    │   ├── Evaluator.hs      <-- For evaluation logic & state
-    │   ├── Parser.hs         <-- For parsing logic
-    │   └── Types.hs          <-- For core data type definitions
-    │
-    └── Main.hs               <-- Executable entry point (REPL)
+.
+├── brainfuchs.cabal
+├── app
+│   └── Main.hs                 <-- Executable entry point (REPL)
+└── interpreter
+    ├── ARCHITECTURE.md
+    ├── MODULE_SPECIFICATIONS.md
+    ├── README.md
+    └───src
+        └── Brainfuck
+            ├── Evaluator.hs      <-- For evaluation logic & state
+            ├── Parser.hs         <-- For parsing logic
+            └── Types.hs          <-- For core data type definitions
 ```
 
-- **`src/Brainfuck`**: Contém a biblioteca central. Este é o componente reutilizável que define a linguagem Brainfuck, parser e motor de avaliação.
-- **`src/Main`**: Contém o ponto de entrada do executável. O arquivo `Main.hs` neste diretório é responsável por conectar os componentes da biblioteca em um REPL interativo.
+- **`interpreter/src/Brainfuck`**: Contém a biblioteca central. Este é o componente reutilizável que define a linguagem Brainfuck, parser e motor de avaliação.
+- **`app`**: Contém o ponto de entrada do executável. O arquivo `Main.hs` neste diretório é responsável por conectar os componentes da biblioteca em um REPL interativo.
 
 ## Compilação e Execução
 
-O projeto é projetado para ser compilado usando uma ferramenta padrão de build Haskell como Cabal ou Stack. A equipe de integração Cabal é responsável por criar o arquivo `package.yaml` ou `.cabal` necessário.
+O projeto pode ser compilado utilizando Cabal como ferramenta de build.
 
-### Execução Manual (Para Desenvolvimento)
-
-Antes do sistema formal de build ser configurado, o REPL pode ser executado diretamente da raiz do projeto usando `runghc`. Você deve especificar o caminho para o código fonte da biblioteca (flag `-i`):
+Para compilar e executar o projeto usando Cabal, execute na raiz do projeto:
 
 ```bash
-runghc -iinterpreter/src interpreter/src/Main.hs
+cabal run brainfuchs
 ```
 
-### Build Formal (Futuro)
+### Linux: Bibliotecas compartilhadas
 
-Uma vez que o sistema de build esteja em funcionamento, o projeto será compilado e executado com um comando padrão:
+No linux, ao compilar o projeto a partir do código fonte pode ser que ocorra o seguinte erro:
 
+> /usr/bin/ld: cannot find -lgmp: No such file or directory
+
+Normalmente isso significa que os **headers de desenvolvimento** ou os **symlinks para o linker** estão ausentes.
+No Linux, o GHC precisa do `libgmp.so` (o symlink sem versão), e não apenas do `libgmp.so.10`.
+
+Para resolver este erro, é necessário instalar o pacote `gmp-devel`.
+
+- Ubuntu/Debian:
 ```bash
-# Exemplo usando cabal
-cabal run brainfuck-interpreter
+sudo apt update
+sudo apt install libgmp-dev
 ```
 
-> [!NOTE]
-> Este será o procedimento padrão uma vez que a fase de integração esteja completa.
+- Fedora:
+```bash
+sudo dnf install gmp-devel
+```

--- a/interpreter/src/Brainfuck/Evaluator.hs
+++ b/interpreter/src/Brainfuck/Evaluator.hs
@@ -5,7 +5,7 @@ where
 
 import Brainfuck.Types (BfComputation, BfState, CellModFn, Instruction (..), Program, Tape (..))
 import Control.Exception (IOException, try)
-import Control.Monad (mapM_, when)
+import Control.Monad (when)
 import Control.Monad.State.Strict (StateT, evalStateT, get, gets, liftIO, modify)
 import Data.Char (chr, ord)
 import Data.Word (Word8)
@@ -81,3 +81,4 @@ run :: Program -> IO ()
 run prog =
   let initialTape = Tape [] defaultValue []
    in evalStateT (eval prog) initialTape
+

--- a/interpreter/src/Brainfuck/Parser.hs
+++ b/interpreter/src/Brainfuck/Parser.hs
@@ -55,7 +55,7 @@ parseTopLevel ((col, c) : cs) =
 -- entrada terminar antes de um ']', ocorre um erro de colchetes.
 parseLoopBody :: [IndexedCmd] -> Either ParseError (Program, [IndexedCmd])
 parseLoopBody [] = Left MismatchedBrackets
-parseLoopBody ((col, c) : cs) =
+parseLoopBody ((_, c) : cs) =
   case c of
     ']' -> Right ([], cs)
     '[' -> do


### PR DESCRIPTION
- Roda build e testes ao abrir PR pra `main` ou pra `develop`
- Em push pra `develop` gera pré-release com versão beta
- Em push de tag de nova versão no formato `vA.B.C` gera nova release
- Formata o `CHANGELOG.md` seguindo padrão [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
- Versionamento seguindo padrão [PVP](https://pvp.haskell.org/)