### PR TITLE
Feat/compiler

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -51,13 +51,44 @@ jobs:
     - name: Update cabal
       run: cabal update
 
-    - name: Build project
+    - name: Build interpreter
       run: cabal build exe:brainfuchs
+
+    - name: Build compiler
+      if: matrix.os == 'ubuntu-latest'
+      run: cabal build exe:bfhsc
 
     - name: Run tests
       run: cabal test --test-show-details=direct
 
-    - name: Get binary name
+    - name: Create release directory
+      run: mkdir -p release
+
+    - name: Get compiler binary name
+      if: matrix.os == 'ubuntu-latest'
+      id: get-compiler-binary
+      shell: bash
+      run: |
+        BINARY_PATH=$(cabal list-bin exe:bfhsc)
+        echo "binary-path=$BINARY_PATH" >> $GITHUB_OUTPUT
+        BINARY_NAME=$(basename "$BINARY_PATH")
+        echo "binary-name=$BINARY_NAME" >> $GITHUB_OUTPUT
+
+    - name: Strip compiler binary (Unix)
+      if: matrix.os == 'ubuntu-latest'
+      run: strip ${{ steps.get-compiler-binary.outputs.binary-path }}
+
+    - name: Copy compiler binary to release directory
+      if: matrix.os == 'ubuntu-latest'
+      shell: bash
+      run: |
+        BIN_PATH="${{ steps.get-compiler-binary.outputs.binary-path }}"
+        # Substitui '\' por '/' para normalização de caminhos no Windows usando bash shell.
+        BIN_PATH=$(echo "$BIN_PATH" | sed 's#\\#/#g')
+
+        cp "$BIN_PATH" "release/bfhsc-${{ matrix.artifact-name }}${{ matrix.binary-extension }}"
+
+    - name: Get interpreter binary name
       id: get-binary
       shell: bash
       run: |
@@ -66,14 +97,11 @@ jobs:
         BINARY_NAME=$(basename "$BINARY_PATH")
         echo "binary-name=$BINARY_NAME" >> $GITHUB_OUTPUT
 
-    - name: Strip binary (Unix)
+    - name: Strip interpreter binary (Unix)
       if: matrix.os != 'windows-latest'
       run: strip ${{ steps.get-binary.outputs.binary-path }}
 
-    - name: Create release directory
-      run: mkdir -p release
-
-    - name: Copy binary to release directory
+    - name: Copy interpreter binary to release directory
       shell: bash
       run: |
         BIN_PATH="${{ steps.get-binary.outputs.binary-path }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,13 +85,44 @@ jobs:
     - name: Update cabal
       run: cabal update
 
-    - name: Build project
+    - name: Build interpreter
       run: cabal build exe:brainfuchs
+
+    - name: Build compiler
+      if: matrix.os == 'ubuntu-latest'
+      run: cabal build exe:bfhsc
 
     - name: Run tests
       run: cabal test --test-show-details=direct
 
-    - name: Get binary name
+    - name: Create release directory
+      run: mkdir -p release
+
+    - name: Get compiler binary name
+      if: matrix.os == 'ubuntu-latest'
+      id: get-compiler-binary
+      shell: bash
+      run: |
+        BINARY_PATH=$(cabal list-bin exe:bfhsc)
+        echo "binary-path=$BINARY_PATH" >> $GITHUB_OUTPUT
+        BINARY_NAME=$(basename "$BINARY_PATH")
+        echo "binary-name=$BINARY_NAME" >> $GITHUB_OUTPUT
+
+    - name: Strip compiler binary (Unix)
+      if: matrix.os == 'ubuntu-latest'
+      run: strip ${{ steps.get-compiler-binary.outputs.binary-path }}
+
+    - name: Copy compiler binary to release directory
+      if: matrix.os == 'ubuntu-latest'
+      shell: bash
+      run: |
+        BIN_PATH="${{ steps.get-compiler-binary.outputs.binary-path }}"
+        # Substitui '\' por '/' para normalização de caminhos no Windows usando bash shell.
+        BIN_PATH=$(echo "$BIN_PATH" | sed 's#\\#/#g')
+
+        cp "$BIN_PATH" "release/bfhsc-${{ matrix.artifact-name }}${{ matrix.binary-extension }}"
+
+    - name: Get interpreter binary name
       id: get-binary
       shell: bash
       run: |
@@ -100,14 +131,11 @@ jobs:
         BINARY_NAME=$(basename "$BINARY_PATH")
         echo "binary-name=$BINARY_NAME" >> $GITHUB_OUTPUT
 
-    - name: Strip binary (Unix)
+    - name: Strip interpreter binary (Unix)
       if: matrix.os != 'windows-latest'
       run: strip ${{ steps.get-binary.outputs.binary-path }}
 
-    - name: Create release directory
-      run: mkdir -p release
-
-    - name: Copy binary to release directory
+    - name: Copy interpreter binary to release directory
       shell: bash
       run: |
         BIN_PATH="${{ steps.get-binary.outputs.binary-path }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,8 +37,12 @@ jobs:
     - name: Update cabal package list
       run: cabal update
 
-    - name: Build project
+    - name: Build interpreter
       run: cabal build exe:brainfuchs
+
+    - name: Build compiler
+      if: matrix.os == 'ubuntu-latest'
+      run: cabal build exe:bfhsc
 
     - name: Run tests
       run: cabal test --test-show-details=direct

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Pasta de build principal do Cabal
 dist-newstyle/
 
+# Arquivos temporários do compilador
+build/
+
 # Arquivos executáveis compilados (ex: .exe no Windows)
 *.exe
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ and this project adheres to the [Haskell Package Versioning Policy](https://pvp.
 ## [Unreleased]
 
 ### Added
-- (Placeholder)
+- Implemented Brainfuck compiler targeting Linux x86-64
+- Library modules:
+  - `AST` - Defines the AST for Brainfuck
+  - `Parser` - Parses Brainfuck code into an AST
+  - `CodeGen` - Translates AST into x86-64 assembly code
+  - `Assembler` - Assembles and links assembly code into executable binary
+- Executable `bfhsc` with entry point in `app/Compiler.hs`
 
 ### Changed
 - (Placeholder)
@@ -21,7 +27,7 @@ and this project adheres to the [Haskell Package Versioning Policy](https://pvp.
 ### Added
 - Initial implementation of the brainfuck interpreter.
 - Library modules:
-  - `Brainfuck.Parser` – parse Brainfuck code into commands.
-  - `Brainfuck.Evaluator` – run Brainfuck programs.
-  - `Brainfuck.Types` – core types (e.g. Tape, Instructions).
+  - `Brainfuck.Parser` – Parses Brainfuck code into an AST.
+  - `Brainfuck.Evaluator` – Runs Brainfuck programs.
+  - `Brainfuck.Types` – Defines the core types (e.g. Tape, Instructions).
 - Executable `brainfuchs` with CLI entry point in `app/Main.hs`.

--- a/app/Compiler.hs
+++ b/app/Compiler.hs
@@ -1,6 +1,5 @@
 module Main where
 
-import AST
 import Assembler
 import CodeGen
 import Parser

--- a/app/Compiler.hs
+++ b/app/Compiler.hs
@@ -1,0 +1,26 @@
+module Main where
+
+import AST
+import Assembler
+import CodeGen
+import Parser
+
+-- Importar ferramentas do Sistema
+import System.Environment (getArgs)
+import System.Exit (die)
+
+-- Função main que o Cabal vai executar
+main :: IO ()
+main = do
+  args <- getArgs
+  case args of
+    [inputFile, outputFile] -> do
+      putStrLn $ "Compilando (bfhsc): '" ++ inputFile ++ "' -> '" ++ outputFile ++ "'"
+      brainfuckCode <- readFile inputFile
+      case parse brainfuckCode of
+        Left err -> die ("Erro de Parser " ++ err)
+        Right ast -> do
+          let assembly = generateAssembly ast
+          createExecutable assembly outputFile
+    _ -> do
+      putStrLn "Uso: bfhsc <arq_entrada.bf> <arq_saida>"

--- a/brainfuchs.cabal
+++ b/brainfuchs.cabal
@@ -33,7 +33,9 @@ library brainfuchs-compiler
         CodeGen,
         Assembler
     build-depends:
-        process
+        process,
+        directory,
+        filepath
     hs-source-dirs:   compiler/src
 
 executable brainfuchs

--- a/brainfuchs.cabal
+++ b/brainfuchs.cabal
@@ -15,7 +15,7 @@ common common-settings
     build-depends:    base >= 4.17 && < 5
     default-language: Haskell2010
 
-library
+library brainfuchs-interpreter
     import:           common-settings
     exposed-modules:
         Brainfuck.Evaluator,
@@ -25,9 +25,27 @@ library
         mtl
     hs-source-dirs:   interpreter/src
 
+library brainfuchs-compiler
+    import:           common-settings
+    exposed-modules:
+        AST,
+        Parser,
+        CodeGen,
+        Assembler
+    build-depends:
+        process
+    hs-source-dirs:   compiler/src
+
 executable brainfuchs
     import:           common-settings
     main-is:          Main.hs
     build-depends:
-        brainfuchs
+        brainfuchs-interpreter
+    hs-source-dirs:   app
+
+executable bfhsc
+    import:           common-settings
+    main-is:          Compiler.hs
+    build-depends:
+      brainfuchs-compiler
     hs-source-dirs:   app

--- a/compiler/ARCHITECTURE.md
+++ b/compiler/ARCHITECTURE.md
@@ -1,0 +1,81 @@
+# Arquitetura do Compilador Brainfuchs (bfhsc)
+
+Este documento descreve a arquitetura do `bfhsc`, o compilador de Brainfuck para Assembly x86-64 (Linux) escrito em Haskell.
+
+## 1. Visão Geral
+
+O compilador é uma aplicação de linha de comando que transforma um arquivo de código-fonte Brainfuck (`.bf`) em um executável nativo. O processo é um pipeline linear que consiste em três fases principais: **Parsing**, **Geração de Código** e **Montagem**.
+
+O fluxo de dados é o seguinte:
+
+`Arquivo .bf` → `String` → **[Parser]** → `AST` → **[CodeGen]** → `String (Assembly)` → **[Assembler]** → `Executável`
+
+A compilação depende de ferramentas externas do sistema (`nasm` e `gcc`) e o código gerado é linkado com a biblioteca padrão do C para funcionalidades de I/O (`putchar`, `getchar`).
+
+## 2. Componentes Principais
+
+O código do compilador é modular e está localizado em `compiler/src/`. Cada módulo tem uma responsabilidade bem definida.
+
+### 2.1. `AST.hs` (Abstract Syntax Tree)
+
+* **Responsabilidade:** Define a estrutura de dados central que representa o programa Brainfuck de forma abstrata. É a "linguagem universal" que conecta o Parser e o Gerador de Código.
+* **Estrutura Principal:**
+    * `data Cmd`: Um tipo de dado que representa cada uma das 7 instruções possíveis do Brainfuck (`Incr`, `Decr`, `Next`, `Prev`, `Print`, `Input`, `Loop [Cmd]`).
+    * `type AST = [Cmd]`: Um alias de tipo que define um programa completo como uma lista de instruções `Cmd`.
+
+### 2.2. `Parser.hs`
+
+* **Responsabilidade:** Transformar o código-fonte Brainfuck (uma `String`) em sua representação estruturada (a `AST`).
+* **Entrada:** `String` com o código `.bf`.
+* **Saída:** `Either String AST`. Retorna a `AST` em caso de sucesso (`Right AST`) ou uma mensagem de erro em caso de falha (`Left String`).
+* **Detalhes de Implementação:**
+    * Utiliza uma abordagem de **descida recursiva** (`recursive descent`) para analisar o código.
+    * A função principal `parse'` é capaz de lidar com loops `[]` aninhados chamando a si mesma para analisar o conteúdo de um loop.
+    * Qualquer caractere que não seja um dos 8 comandos Brainfuck é tratado como um comentário e elegantemente ignorado, conforme a especificação da linguagem.
+
+### 2.3. `CodeGen.hs` (Code Generator)
+
+* **Responsabilidade:** Transformar a `AST` em uma `String` contendo o código Assembly x86-64 para a plataforma Linux.
+* **Entrada:** `AST`.
+* **Saída:** `String` com o código Assembly completo.
+* **Detalhes de Implementação:**
+    * **Estrutura de Sanduíche:** O código final é montado a partir de um `generateHeader` (que define a fita de memória, o ponto de entrada `main` e declara as funções externas do C) e um `generateFooter` (que finaliza o programa).
+    * **Tradução Recursiva:** A função principal `astToAsm` percorre a `AST`. Para lidar com loops aninhados, ela passa um **contador de estado (`Int`)** para gerar labels únicos (ex: `loop_start_0`, `loop_end_0`, `loop_start_1`, etc.).
+    * **Link com C:** As instruções `.` e `,` são traduzidas em chamadas (`call`) para as funções `putchar` e `getchar` da biblioteca C. O ponteiro da fita Brainfuck é mantido no registrador `rbx` para eficiência.
+
+### 2.4. `Assembler.hs`
+
+* **Responsabilidade:** Orquestrar as ferramentas externas para transformar a `String` de Assembly em um executável final.
+* **Entrada:** `String` com o código Assembly e um `FilePath` para o nome do arquivo de saída.
+* **Saída:** Nenhuma (`IO ()`). O resultado são os arquivos criados no sistema.
+* **Detalhes de Implementação:**
+    * Utiliza a biblioteca `System.Process` (função `callCommand`) e `System.IO` (função `writeFile`).
+    * O processo ocorre em 3 passos:
+        1.  O código Assembly é salvo em um arquivo temporário (`.s`).
+        2.  O `nasm` é chamado para montar o arquivo `.s` em um arquivo objeto (`.o`).
+        3.  O `gcc` é chamado para linkar o arquivo `.o` com a biblioteca C, usando a flag `-no-pie` para compatibilidade, e gerar o executável final.
+
+## 3. Fluxo de Compilação
+
+Quando um usuário executa `bfhsc entrada.bf saida`, o seguinte acontece:
+
+1.  O `main` em `app/Compiler.hs` lê os argumentos e o conteúdo de `entrada.bf`.
+2.  O conteúdo é passado para a função `parse` do módulo `Parser`.
+3.  Se o parsing for bem-sucedido, a `AST` resultante é passada para a função `generateAssembly` do módulo `CodeGen`.
+4.  A `String` de Assembly resultante é passada, junto com o nome `saida`, para a função `createExecutable` do módulo `Assembler`.
+5.  O `Assembler` executa os comandos `writeFile`, `nasm` e `gcc`, criando o arquivo executável `saida`.
+6.  Uma mensagem de sucesso é impressa no terminal.
+
+## 4. Como Construir e Executar
+
+O projeto é gerenciado pelo Cabal. Todos os comandos devem ser executados a partir do diretório raiz do projeto.
+
+* **Construir o Projeto:** Compila todas as bibliotecas e executáveis.
+    ```bash
+    cabal build
+    ```
+
+* **Executar o Compilador:**
+    ```bash
+    cabal run bfhsc -- <arquivo_entrada.bf> <arquivo_saida>
+    ```

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -1,0 +1,36 @@
+# Compilador BrainfucHS (bfhsc)
+
+Este diretório (`compiler/`) contém todo o código-fonte da biblioteca e do executável para o compilador de Brainfuck para Linux x86-64.
+
+O objetivo deste componente é transformar código-fonte Brainfuck (`.bf`) em executáveis nativos e performáticos.
+
+## Arquitetura e Fluxo de Dados
+
+O compilador opera em um pipeline de três estágios principais, onde a saída de um estágio é a entrada do próximo:
+
+1.  **Parsing (`Parser.hs`):** O código-fonte em formato `String` é lido e transformado em uma representação de dados estruturada, a Árvore Sintática Abstrata (`AST`).
+2.  **Geração de Código (`CodeGen.hs`):** A `AST` é percorrida e traduzida para uma `String` contendo o código Assembly x86-64 equivalente.
+3.  **Montagem (`Assembler.hs`):** A `String` de Assembly é salva em um arquivo e orquestra a chamada de ferramentas externas (`nasm`, `gcc`) para gerar o executável final.
+
+## Estrutura dos Módulos (`compiler/src/`)
+
+A lógica principal do compilador é dividida em quatro módulos:
+
+* **`AST.hs`**: Define a `AST` (`type AST = [Cmd]`), a estrutura de dados que serve como a "linguagem universal" entre as fases do compilador.
+* **`Parser.hs`**: Expõe a função `parse`, que implementa um parser de descida recursiva para transformar `String` em `AST`, tratando corretamente loops aninhados e ignorando comentários.
+* **`CodeGen.hs`**: Expõe a função `generateAssembly`, que traduz a `AST` para Assembly. Gerencia um estado de contador para criar labels de loop únicos e prepara o código para ser linkado com a biblioteca C (`putchar`, `getchar`).
+* **`Assembler.hs`**: Expõe a função `createExecutable`, que interage com o sistema para chamar `nasm` e `gcc` (com a flag `-no-pie`) e gerar o binário final.
+
+## Ponto de Entrada
+
+O ponto de entrada para a ferramenta de linha de comando `bfhsc` não está neste diretório. Ele está localizado na raiz do projeto, em `app/Compiler.hs`, conforme a convenção do projeto. Esse arquivo é responsável por ler os argumentos da linha de comando (arquivos de entrada/saída) e invocar a pipeline de compilação exposta por esta biblioteca.
+
+## Como Construir e Usar
+
+Todo o projeto é gerenciado pelo arquivo `brainfuchs.cabal` na raiz. Os comandos devem ser executados a partir do diretório raiz.
+
+### Construir a Biblioteca do Compilador
+
+Para compilar apenas esta biblioteca (e suas dependências):
+```bash
+cabal build brainfuchs-compiler

--- a/compiler/src/AST.hs
+++ b/compiler/src/AST.hs
@@ -1,0 +1,13 @@
+module AST where
+
+data Cmd
+  = Next -- >
+  | Prev -- <
+  | Incr -- +
+  | Decr -- -
+  | Print -- .
+  | Input -- ,
+  | Loop [Cmd] -- [...]
+
+-- Criando tipo AST pela facilidade de leitura e manutenção
+type AST = [Cmd]

--- a/compiler/src/AST.hs
+++ b/compiler/src/AST.hs
@@ -8,6 +8,7 @@ data Cmd
   | Print -- .
   | Input -- ,
   | Loop [Cmd] -- [...]
+  deriving (Show)
 
 -- Criando tipo AST pela facilidade de leitura e manutenção
 type AST = [Cmd]

--- a/compiler/src/Assembler.hs
+++ b/compiler/src/Assembler.hs
@@ -21,6 +21,6 @@ createExecutable assemblyCode outputFilename = do
   putStrLn $ "Montando com NASM " ++ asmFile ++ " -> " ++ objFile ++ "..."
   callCommand ("nasm -felf64 " ++ asmFile ++ " -o " ++ objFile) -- felf64 está indicando que é para o formato x86_64 do Linux
   putStrLn $ "Linkando com GCC: " ++ objFile ++ " -> " ++ outputFilename ++ "..."
-  callCommand ("gcc " ++ objFile ++ " -o " ++ outputFilename)
+  callCommand ("gcc -no-pie " ++ objFile ++ " -o " ++ outputFilename)
 
   putStrLn $ "Executavel '" ++ outputFilename ++ "' criado com sucesso!"

--- a/compiler/src/Assembler.hs
+++ b/compiler/src/Assembler.hs
@@ -1,0 +1,26 @@
+module Assembler (
+  createExecutable,
+) where
+
+-- Roda comandos de terminal
+import System.IO (writeFile) -- Escreve em arquivos (O nome ja diz)
+import System.Process (callCommand)
+
+-- Função principal
+-- IO () significa que o programa vai realizar ações em arquivos externos (escrever em arquivos e chamar programas)
+-- IO () não retorna valor
+createExecutable :: String -> FilePath -> IO ()
+createExecutable assemblyCode outputFilename = do
+  let asmFile = "temp.s"
+  let objFile = "temp.o"
+
+  -- Aqui o 'do' se mostra útil, deixando o código mais limpo em comandos sequenciais
+  putStrLn $ "Escrevendo codigo Assembly para " ++ asmFile ++ "..."
+  writeFile asmFile assemblyCode
+
+  putStrLn $ "Montando com NASM " ++ asmFile ++ " -> " ++ objFile ++ "..."
+  callCommand ("nasm -felf64 " ++ asmFile ++ " -o " ++ objFile) -- felf64 está indicando que é para o formato x86_64 do Linux
+  putStrLn $ "Linkando com GCC: " ++ objFile ++ " -> " ++ outputFilename ++ "..."
+  callCommand ("gcc " ++ objFile ++ " -o " ++ outputFilename)
+
+  putStrLn $ "Executavel '" ++ outputFilename ++ "' criado com sucesso!"

--- a/compiler/src/Assembler.hs
+++ b/compiler/src/Assembler.hs
@@ -3,7 +3,9 @@ module Assembler (
 ) where
 
 -- Roda comandos de terminal
-import System.IO (writeFile) -- Escreve em arquivos (O nome ja diz)
+
+import System.Directory.OsPath (createDirectoryIfMissing)
+import System.OsPath (encodeFS)
 import System.Process (callCommand)
 
 -- Função principal
@@ -11,8 +13,13 @@ import System.Process (callCommand)
 -- IO () não retorna valor
 createExecutable :: String -> FilePath -> IO ()
 createExecutable assemblyCode outputFilename = do
-  let asmFile = "temp.s"
-  let objFile = "temp.o"
+  let buildDir = "build/"
+  let asmFile = buildDir ++ "temp.s"
+  let objFile = buildDir ++ "temp.o"
+
+  -- Cria diretório para os artefatos de build, caso não exista
+  buildPath <- encodeFS buildDir
+  _ <- createDirectoryIfMissing True buildPath
 
   -- Aqui o 'do' se mostra útil, deixando o código mais limpo em comandos sequenciais
   putStrLn $ "Escrevendo codigo Assembly para " ++ asmFile ++ "..."

--- a/compiler/src/CodeGen.hs
+++ b/compiler/src/CodeGen.hs
@@ -1,0 +1,88 @@
+module CodeGen (
+  generateAssembly, -- esta função será exportada
+) where
+
+import AST
+
+-- Função principal -> gera Assembly a partir do AST
+generateAssembly :: AST -> String
+generateAssembly ast =
+  generateHeader ++ fst (astToAsm ast 0) ++ generateFooter
+-- ** fst (a, b) -> a **
+
+-- Função de tradução
+astToAsm :: AST -> Int -> (String, Int)
+astToAsm [] countr = ("", countr)
+astToAsm (cmd : restoDaAst) countr =
+  case translateCmd cmd countr of -- executa a tradução da primeira instrução
+    (asm1, countr1) ->
+      -- se deu certo, códido asm1 e countr1 são retornados
+      -- com o contador atualizado, executamos a tradução do resto da lista
+      case astToAsm restoDaAst countr1 of
+        (asm2, countr2) ->
+          -- se deu certo, temos agora o asm2 e o contador atualizado
+          (asm1 ++ asm2, countr2) -- junta o codigo da primeira instrução com o resto e passa o contador final
+
+-- Função auxiliar do asmToAst
+translateCmd :: Cmd -> Int -> (String, Int) -- Através de Pattern Matching, analisa cada Cmd do AST
+translateCmd Incr countr = ("    inc byte [rbx]\n", countr)
+translateCmd Decr countr = ("    dec byte [rbx]\n", countr)
+translateCmd Next countr = ("    inc rbx\n", countr)
+translateCmd Prev countr = ("    dec rbx\n", countr)
+translateCmd Print countr =
+  ( unlines
+      [ "    movzx rdi, byte [rbx]" -- movzx é mais seguro pra copiar um byte para um registrador maior
+      , "    call putchar" -- imprime com a função do C
+      ]
+  , countr
+  )
+translateCmd Input countr =
+  ( unlines
+      [ "    call getchar" -- lê um caractere com a função do C
+      , "    mov [rbx], al" -- Salva o resultado na memória
+      ]
+  , countr
+  )
+translateCmd (Loop innerAst) countr =
+  case astToAsm innerAst (countr + 1) of
+    (asmDoLoop, countrFinal) ->
+      ( unlines
+          [ ("loop_start_" ++ show countr) ++ ":"
+          , "    cmp byte [rbx], 0"
+          , "    je " ++ ("loop_end_" ++ show countr)
+          , asmDoLoop
+          , "    jmp " ++ ("loop_start_" ++ show countr)
+          , ("loop_end_" ++ show countr) ++ ":"
+          ]
+      , countrFinal
+      )
+
+-- Funções auxiliares do generateAssembly
+generateHeader :: String -- Cabeçalho Assembly
+generateHeader =
+  unlines
+    [ -- unlines pega um [String] e retorna todos os elementos os separando por \n
+      "section .data"
+    , "    memory: times 30000 db 0" -- tape de 30K bytes, tudo como 0
+    , "    pointer: dq memory" -- ponteiro apontando para a posição de memória atual
+    , ""
+    , "section .text"
+    , "    global main" -- torna o main visível para o Linker do C (gcc)
+    , "    extern putchar" -- extern pega funções do C para usar no Assembly
+    , "    extern getchar"
+    , ""
+    , "main:" -- seguindo as regras do C, não se usa _start, mas sim 'main'
+    , "    push rbp"
+    , "    mov rbp, rsp"
+    , "    mov rbx, [pointer]" -- carega o ponteiro para rbx no inicio
+    ]
+
+generateFooter :: String -- Rodapé do Assembly
+generateFooter =
+  unlines
+    [ -- Fim padrão de um programa Assembly
+      "    mov [pointer], rbx" -- Salva a posição final do ponteiro
+    , "    mov rax, 0"
+    , "    pop rbp"
+    , "    ret"
+    ]

--- a/compiler/src/Parser.hs
+++ b/compiler/src/Parser.hs
@@ -23,6 +23,7 @@ parse' ('[' : resto) =
             Left err -> Left err
             -- Finalmente, joga o 'astLoop' dentro do Loop do AST e continua com o parser'
             Right (astFinal, strFinal) -> Right (Loop astLoop : astFinal, strFinal)
+        _ -> Left "Erro de sintaxe: ']' esperado para fechar o loop."
 --
 -- lidando com os outros caracteres
 parse' (c : resto) =

--- a/compiler/src/Parser.hs
+++ b/compiler/src/Parser.hs
@@ -1,0 +1,62 @@
+module Parser (
+  parse, -- exporta essa função (publica)
+)
+where
+
+import AST -- importa o arquivo AST.hs
+
+-- uso do apóstrofo como convenção de função que será auxiliar da publica
+parse' :: String -> Either String (AST, String)
+parse' [] = Right ([], []) -- String Vazia = FIM
+
+-- começando com o loop pra ter menos dor de cabeça depois
+parse' (']' : resto) = Right ([], resto)
+parse' ('[' : resto) =
+  case parse' resto of
+    Left err -> Left err -- retorno de erro
+    Right (astLoop, restoFora) ->
+      -- resto de fora do loop e o ast de dentro
+      case parse' restoFora of
+        Left err -> Left err
+        -- Finalmente, joga o 'astLoop' dentro do Loop do AST e continua com o parser'
+        Right (astFinal, strFinal) -> Right (Loop astLoop : astFinal, strFinal)
+-- lidando com os outros caracteres
+parse' (c : resto) =
+  case c of
+    '+' ->
+      case parse' resto of
+        Left err -> Left err
+        Right (astResto, strFinal) -> Right (Incr : astResto, strFinal)
+    '-' ->
+      case parse' resto of
+        Left err -> Left err
+        Right (astResto, strFinal) -> Right (Decr : astResto, strFinal)
+    '>' ->
+      case parse' resto of
+        Left err -> Left err
+        Right (astResto, strFinal) -> Right (Next : astResto, strFinal)
+    '<' ->
+      case parse' resto of
+        Left err -> Left err
+        Right (astResto, strFinal) -> Right (Prev : astResto, strFinal)
+    '.' ->
+      case parse' resto of
+        Left err -> Left err
+        Right (astResto, strFinal) -> Right (Print : astResto, strFinal)
+    ',' ->
+      case parse' resto of
+        Left err -> Left err
+        Right (astResto, strFinal) -> Right (Input : astResto, strFinal)
+
+-- ! FUNÇÃO PARSE PÚBLICA ! --
+parse :: String -> Either String AST
+parse input =
+  case parse' input of
+    Left err -> Left err
+    -- se o resto for null, significa que o bendito parse' analisou tudo sem sobrar código
+    Right (ast, resto) ->
+      if null resto -- tentei usar guards, mas só funciona com if-then-else
+        then
+          Right ast
+        else
+          Left "Erro de Sintaxe"

--- a/compiler/src/Parser.hs
+++ b/compiler/src/Parser.hs
@@ -47,6 +47,7 @@ parse' (c : resto) =
       case parse' resto of
         Left err -> Left err
         Right (astResto, strFinal) -> Right (Input : astResto, strFinal)
+    _ -> parse' resto -- Ignora caracteres inválidos como se fossem comentários
 
 -- ! FUNÇÃO PARSE PÚBLICA ! --
 parse :: String -> Either String AST

--- a/compiler/src/Parser.hs
+++ b/compiler/src/Parser.hs
@@ -23,8 +23,6 @@ parse' ('[' : resto) =
             Left err -> Left err
             -- Finalmente, joga o 'astLoop' dentro do Loop do AST e continua com o parser'
             Right (astFinal, strFinal) -> Right (Loop astLoop : astFinal, strFinal)
-            -- Para fins de teste, não deve acontecer!
-            _ -> Left "Erro de parser: estado inesperado apos um Loop!"
 --
 -- lidando com os outros caracteres
 parse' (c : resto) =

--- a/compiler/src/Parser.hs
+++ b/compiler/src/Parser.hs
@@ -10,16 +10,22 @@ parse' :: String -> Either String (AST, String)
 parse' [] = Right ([], []) -- String Vazia = FIM
 
 -- começando com o loop pra ter menos dor de cabeça depois
-parse' (']' : resto) = Right ([], resto)
+parse' (']' : resto) = Right ([], ']' : resto)
 parse' ('[' : resto) =
   case parse' resto of
     Left err -> Left err -- retorno de erro
     Right (astLoop, restoFora) ->
       -- resto de fora do loop e o ast de dentro
-      case parse' restoFora of
-        Left err -> Left err
-        -- Finalmente, joga o 'astLoop' dentro do Loop do AST e continua com o parser'
-        Right (astFinal, strFinal) -> Right (Loop astLoop : astFinal, strFinal)
+      case restoFora of
+        [] -> Left "Erro: loop '[' nao foi fechado!"
+        (']' : restoDepoisDoLoop) ->
+          case parse' restoDepoisDoLoop of
+            Left err -> Left err
+            -- Finalmente, joga o 'astLoop' dentro do Loop do AST e continua com o parser'
+            Right (astFinal, strFinal) -> Right (Loop astLoop : astFinal, strFinal)
+            -- Para fins de teste, não deve acontecer!
+            _ -> Left "Erro de parser: estado inesperado apos um Loop!"
+--
 -- lidando com os outros caracteres
 parse' (c : resto) =
   case c of


### PR DESCRIPTION
Adição do compilador `bfhsc` ao projeto, permitindo a compilação de arquivos `.bf` para executáveis nativos em Linux x86-64.

* Criada a biblioteca do compilador (`brainfuchs-compiler`) na pasta `compiler/src`, contendo os módulos `AST`, `Parser`, `CodeGen` e `Assembler`.
* Adicionado o executável `bfhsc` com o ponto de entrada em `app/Compiler.hs`.
* Atualizado o arquivo `brainfuchs.cabal` para incluir a nova biblioteca e o novo executável.
* Adicionada documentação (`README.md`, `ARCHITECTURE.md`) na pasta `compiler/`.

## Como Testar

Para testar, a partir da raiz do projeto:

1.  **Construa o projeto:**
    ```bash
    cabal build
    ```

2.  **Crie um arquivo de teste:**
    ```bash
    echo "++++++[>++++++++++<-]>+++++." > exemplos/letra_a.bf
    ```

3.  **Use o compilador `bfhsc` para gerar um executável:**
    ```bash
    cabal run bfhsc -- exemplos/letra_a.bf prog_a
    ```

4.  **Execute o programa recém-criado:**
    ```bash
    ./prog_a
    ```

## Resultado Esperado

O terminal deve imprimir a letra `A`.